### PR TITLE
Remove extra async ampersand

### DIFF
--- a/common/etc/sway/variables
+++ b/common/etc/sway/variables
@@ -65,7 +65,7 @@ set $idle swayidle -w \
     timeout $screen_timeout 'swaymsg "output * power off"' \
     resume 'swaymsg "output * power on"' \
     before-sleep 'playerctl pause' \
-    before-sleep $lock & \
+    before-sleep $lock \
     lock $lock &
 
 # Pulseaudo command


### PR DESCRIPTION
I think there is an extra ampersand here, that causes an error during startup "lock: command not found".