### PR TITLE
Do not apply NVIDIA specific variables on PRIME setups

### DIFF
--- a/data/ubuntusway/bin/start-sway
+++ b/data/ubuntusway/bin/start-sway
@@ -11,7 +11,7 @@ qemu|kvm|oracle)
 esac
 
 # Apply Nvidia-specific variables
-if [ -d /sys/module/nvidia ]; then
+if [ -d /sys/module/nvidia ] && [ ! -d /sys/module/amdgpu ] && [ ! -d /sys/module/i915 ]; then
     export WLR_NO_HARDWARE_CURSORS=1
     export GBM_BACKEND=nvidia-drm
     export __GLX_VENDOR_LIBRARY_NAME=nvidia

--- a/data/ubuntusway/bin/start-sway
+++ b/data/ubuntusway/bin/start-sway
@@ -4,12 +4,8 @@
 case "$(systemd-detect-virt)" in
 qemu)
   export WLR_RENDERER=pixman
-  export WLR_NO_HARDWARE_CURSORS=1
-  ;;
-kvm)
-  export WLR_NO_HARDWARE_CURSORS=1
-  ;;
-oracle)
+  ;&
+qemu|kvm|oracle)
   export WLR_NO_HARDWARE_CURSORS=1
   ;;
 esac


### PR DESCRIPTION
On laptops with PRIME, we should not export variables for NVIDIA, since Sway rendering should be done on the iGPU. However, we still need to run sway with `--unsupported-gpu`, since Sway always requires it if it finds a dGPU.