### PR TITLE
Fix appending user keybindings to help

### DIFF
--- a/common/usr/share/sway/scripts/sbdp.py
+++ b/common/usr/share/sway/scripts/sbdp.py
@@ -2,6 +2,7 @@
 import sys
 import glob
 import re
+import os
 from typing import Text
 import json
 
@@ -26,6 +27,7 @@ def readFile(filePath):
     for line in allLines:
         if re.search(r'^include\s+(.+?)$', line):
             nextPath = re.findall(r'^include\s+(.+?)$', line)[0]
+            nextPath = os.path.expandvars(nextPath)
             finalLines = finalLines + readFile(nextPath)
         else:
             finalLines = finalLines + [line]


### PR DESCRIPTION
Reference: https://github.com/manjaro-sway/desktop-settings/commit/8642fc01f8523363c3456dded82d84d56580ea26

Without this fix, any keybinding set in the user config is not included in the help displayed on the desktop.