### PR TITLE
Allow styling waybar sunset module according to its status

### DIFF
--- a/common/usr/share/sway/scripts/sunset.sh
+++ b/common/usr/share/sway/scripts/sunset.sh
@@ -61,4 +61,4 @@ else
     tooltip="Night Color mode: disabled"
 fi
 
-printf '{"alt":"%s", "tooltip":"%s"}\n' "$class" "$tooltip"
+printf '{"alt":"%s", "tooltip":"%s", "class": "%s"}\n' "$class" "$tooltip" "$class"


### PR DESCRIPTION
Adding the "class" attribute allows defining the #custom-wlsunset.on and #custom-wlsunset.off styles