### PR TITLE
Add error handling for `weather.py` when internet connection not initialized

### DIFF
--- a/common/usr/share/sway/scripts/weather.py
+++ b/common/usr/share/sway/scripts/weather.py
@@ -88,8 +88,10 @@ try:
 except (KeyError, Exception):
     city = ""
 
-weather = requests.get(f"https://wttr.in/{city}?format=j1").json()
-
+try:
+    weather = requests.get(f"https://wttr.in/{city}?format=j1").json()
+except ConnectionError:
+    sys.exit()
 
 def format_time(time):
     return time.replace("00", "").zfill(2)


### PR DESCRIPTION
Often times I will get the following error on startup for the weather applet if my internet connection hasn't fully connected yet:

```
 Traceback (most recent call last):
   File "/usr/share/sway/scripts/weather.py", line 91, in <module>
     weather = requests.get(f"https://wttr.in/{city}?format=j1").json()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/requests/api.py", line 73, in get
     return request("get", url, params=params, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/requests/api.py", line 59, in request
     return session.request(method=method, url=url, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/requests/sessions.py", line 589, in request
     resp = self.send(prep, **send_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/requests/sessions.py", line 703, in send
     r = adapter.send(request, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/requests/adapters.py", line 519, in send
     raise ConnectionError(e, request=request)
 requests.exceptions.ConnectionError: HTTPSConnectionPool(host='wttr.in', port=443): Max retries exceeded with url: /?format=j1 (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x783b88aa7770>: Failed to resolve 'wttr.in' ([Errno -3] Temporary failure in name resolution)"))
```

This PR adds a simple try/except for the line where it sends the request. Currently it just exits the script as I'm not sure how you would prefer it handled, it could potentially wait a few seconds and try again but this should at least prevent the error from showing immediately on startup.