### PR TITLE
change the default shortcut for screenrecording

### DIFF
--- a/common/etc/sway/modes/recording.conf
+++ b/common/etc/sway/modes/recording.conf
@@ -13,7 +13,7 @@ mode --pango_markup $mode_recording {
 }
 
 ## Launch // Recording Mode ##
-$bindsym $mod+Shift+r mode $mode_recording
+$bindsym Shift+Print mode $mode_recording
 
 ## Launch // Stop Recording Mode ##
 $bindsym $mod+Escape exec killall -s SIGINT wf-recorder


### PR DESCRIPTION
Today i quickly needed to do a screen recording but i couldn't find the shortcut quickly

since screen recording is screenshots with extra steps (a video is sequence of pictures) it is more intuitive to toggle it with the print screen button— so let's toggle it with Shift+Print